### PR TITLE
When creating a new repo, make "private" checkbox checked by default.…

### DIFF
--- a/Source/GitClientVS.Infrastructure/ViewModels/CreateRepositoriesDialogViewModel.cs
+++ b/Source/GitClientVS.Infrastructure/ViewModels/CreateRepositoriesDialogViewModel.cs
@@ -80,6 +80,7 @@ namespace GitClientVS.Infrastructure.ViewModels
             _gitClientService = gitClientService;
             _gitService = gitService;
             _fileService = fileService;
+            _isPrivate = true;
 
             var path = _gitService.GetDefaultRepoPath();
             LocalPath = !string.IsNullOrEmpty(path) ? path : Paths.DefaultRepositoryPath;

--- a/Source/GitClientVS.Infrastructure/ViewModels/PublishSectionViewModel.cs
+++ b/Source/GitClientVS.Infrastructure/ViewModels/PublishSectionViewModel.cs
@@ -97,6 +97,7 @@ namespace GitClientVS.Infrastructure.ViewModels
             _gitService = gitService;
             _userInformationService = userInformationService;
             _gitWatcher = gitWatcher;
+            _isPrivate = true;
         }
 
 


### PR DESCRIPTION
Matches behavior on bitbucket web interface.

FYI - Had trouble getting unit tests to run.  VS 2017 15.3, ended up getting several of these errors:
[8/15/2017 10:48:08 PM Informational] PowerShellTestContainerDiscoverer:IsTestFile -

And then no tests were found.