### PR TITLE
Clean up MEF log in Visual Studio 2017

### DIFF
--- a/Source/GitClientVS.VisualStudio.UI/source.extension.vsixmanifest
+++ b/Source/GitClientVS.VisualStudio.UI/source.extension.vsixmanifest
@@ -22,8 +22,8 @@
         <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitClientVS.Contracts" Path="|GitClientVS.Contracts|" />
         <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitClientVS.UI" Path="|GitClientVS.UI|" />
         <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitClientVS.Infrastructure" Path="|GitClientVS.Infrastructure|" />
-        <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitClientVS.TeamFoundation.14" Path="|GitClientVS.TeamFoundation.14|" />
-        <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitClientVS.TeamFoundation.15" Path="|GitClientVS.TeamFoundation.15|" />
+        <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitClientVS.TeamFoundation.14" TargetVersion="[14.0,15.0)" Path="|GitClientVS.TeamFoundation.14|" />
+        <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitClientVS.TeamFoundation.15" TargetVersion="[15.0,16.0)" Path="|GitClientVS.TeamFoundation.15|" />
     </Assets>
     <Prerequisites>
         <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0.26004.1,16.0)" DisplayName="Visual Studio core editor" />


### PR DESCRIPTION
## What this PR does

Recent versions of Visual Studio 2017 allow us to specify which versions of Visual Studio a MEF component assembly should be installed in. I can't remember which version of Visual Studio 2017 this feature appeared, but it wasn't there from the beginning.

We can use this to avoid errors in the MEF log when the VSIX Installer attempts to install `GitClientVS.TeamFoundation.14` in Visual Studio 2017. This cleans up the log and makes diagnosing MEF issues a lot easier.

## How to test

1. Install the ClearMEFComponentCache extension
https://marketplace.visualstudio.com/items?itemName=MadsKristensen.ClearMEFComponentCache
2. Install/F5 BitBucket for Visual Studio
3. Run the `Show MEF Errors` command from the `Tools` menu
![image](https://user-images.githubusercontent.com/11719160/43779434-519c397c-9a50-11e8-83b0-1e652f09c02e.png)

Expect to see a nice empty log
![image](https://user-images.githubusercontent.com/11719160/43779606-aeb0c498-9a50-11e8-8c0c-11c08d5fc441.png)

## PS

Hello from GitHub for Visual Studio. 👋 Thanks for the shout out in the readme. 😄 