### PR TITLE
Add workaround for possible MEF issue in Visual Studio 2017

### DIFF
--- a/Source/GitClientVS.VisualStudio.UI/source.extension.vsixmanifest
+++ b/Source/GitClientVS.VisualStudio.UI/source.extension.vsixmanifest
@@ -24,6 +24,8 @@
         <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitClientVS.Infrastructure" Path="|GitClientVS.Infrastructure|" />
         <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitClientVS.TeamFoundation.14" TargetVersion="[14.0,15.0)" Path="|GitClientVS.TeamFoundation.14|" />
         <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitClientVS.TeamFoundation.15" TargetVersion="[15.0,16.0)" Path="|GitClientVS.TeamFoundation.15|" />
+        <!-- Sometimes the version of `ServiceHub.VSDetouredHost.exe` is used when installing for Visual Studio 2017, see https://github.com/github/VisualStudio/pull/1875 -->
+        <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitClientVS.TeamFoundation.15" TargetVersion="[1.0,2.0)" Path="|GitClientVS.TeamFoundation.15|" />
     </Assets>
     <Prerequisites>
         <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0.26004.1,16.0)" DisplayName="Visual Studio core editor" />


### PR DESCRIPTION
@MistyKuu, I'm afraid I introduced a potential issue when installing for Visual Studio 2017 in my #75 PR. You can read about the gory details https://github.com/github/VisualStudio/pull/1875 and https://github.com/github/VisualStudio/issues/1859.

### What this PR does

Sometimes when installing for Visual Studio 2017 the version of `ServiceHub.VSDetouredHost.exe` will be used instead of `devenv.exe`. This means that the version of Visual Studio 2017 can appears as 1.x instead of the expected 15.x.

This workaround installs the `GitClientVS.TeamFoundation.15` MEF asset when the `TargetVersion` is 1.x (as well as the expected 15.x).